### PR TITLE
add KBQA-r1 to RL-Based Agentic Search section

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,10 +393,10 @@ If you find this repository or paper useful, please consider citing the survey p
 | [WebGPT: Browser-assisted question-answering with human feedback](https://arxiv.org/abs/2112.09332) | 2021 |
 | [RAG-RL: Advancing Retrieval-Augmented Generation via RL and Curriculum Learning](https://arxiv.org/abs/2503.12759) | 2025 |
 | [Search-R1: Training LLMs to Reason and Leverage Search Engines with Reinforcement Learning](https://arxiv.org/abs/2503.09516) | 2025 |
+| [KBQA-R1: Reinforcing Large Language Models for Knowledge Base Question Answering](https://arxiv.org/abs/2512.10999) | 2025 |
 | [DeepResearcher: Scaling Deep Research via Reinforcement Learning in Real-World Environments](https://arxiv.org/abs/2504.03160) | 2025 |
 | [ReSearch: Learning to Reason with Search for LLMs via Reinforcement Learning](https://arxiv.org/abs/2503.19470) | 2025 |
 | [ReARTeR: Retrieval-Augmented Reasoning with Trustworthy Process Rewarding](https://arxiv.org/abs/2501.07861) | 2025 |
-| [KBQA-R1: Reinforcing Large Language Models for Knowledge Base Question Answering](https://arxiv.org/abs/2512.10999) | 2025 |
 
 ---
 


### PR DESCRIPTION

**Dear maintainers,**

First of all, thank you for curating this comprehensive survey and list! It has been very helpful for the community.

I would like to propose adding our recent work, **[[KBQA-r1](https://arxiv.org/abs/2512.10999)]**, to the `RL-Based Agentic Search` section under *Foundational Agentic Reasoning*.

**Why this paper fits:**
This paper explores **Agentic Reasoning** in the context of Knowledge Base Question Answering (KBQA). Specifically, it introduces a framework that leverages **Reinforcement Learning** to train LLMs to autonomously navigate knowledge graphs and reason over structured data. By optimizing the reasoning path via RL, the model demonstrates enhanced agentic capabilities in retrieving and processing information, which aligns perfectly with the scope of **RL-Based Agentic Search**.

I believe this work would be a valuable addition for researchers interested in the intersection of KBQA and Agentic Reasoning.

Thank you for your time and consideration!

