### PR TITLE
Add new paper of ICML 2026 about tool-calling evaluation and RL

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ If you find this repository or paper useful, please consider citing the survey p
 
 | Paper | Year |
 | --- | --- |
+| [On Effectiveness and Efficiency of Agentic Tool-calling and RL Training](https://arxiv.org/abs/2606.00135) | ICML 2026 |
 | [Tool-integrated Reinforcement Learning for Repo Deep Search](https://arxiv.org/abs/2508.03012) | ICSE 2026 |
 | [SoRFT: Issue Resolving with Subtask-oriented Reinforced Fine-Tuning](https://aclanthology.org/2025.acl-long.559/) | ACL 2025 |
 | [SWE-RL: Advancing LLM Reasoning via Reinforcement Learning on Open Software Evolution](https://arxiv.org/abs/2502.18449) | 2025 |


### PR DESCRIPTION
Hi! Really thanks for creating and keeping this repo up. It's been a really useful reading map for me.

I'd like to propose our recent ICML 2026 paper for inclusion: "On Effectiveness and Efficiency of Agentic Tool-calling and RL Training".

We find that current tool-calling benchmarks like BFCL are quite brittle:

📌 For the same model, small manual changes to the 𝐬𝐲𝐬𝐭𝐞𝐦 𝐩𝐫𝐨𝐦𝐩𝐭 shift accuracy by ~15% absolute. Similarly, 𝐦𝐮𝐥𝐭𝐢-𝐭𝐮𝐫𝐧 𝐭𝐞𝐦𝐩𝐥𝐚𝐭𝐞 construction, retaining 𝐫𝐞𝐚𝐬𝐨𝐧𝐢𝐧𝐠 𝐡𝐢𝐬𝐭𝐨𝐫𝐲 can influence up to ~8%. Even pure 𝐫𝐚𝐧𝐝𝐨𝐦 𝐬𝐞𝐞𝐝𝐬 alone introduce ~3% variance.

📌 Yet today, each model is evaluated 𝐮𝐧𝐝𝐞𝐫 𝐢𝐭𝐬 𝐨𝐰𝐧 𝐬𝐞𝐭𝐭𝐢𝐧𝐠𝐬, making leaderboard comparisons totally unmeaningful somehow!

📌 We also construct the data and use RL to fine-tune small models to obtain SOTA performance on multi-turn tool-calling. 

arXiv: https://arxiv.org/abs/2606.00135

BibTeX:
```bash
@article{liu2026effectiveness,
  title={On Effectiveness and Efficiency of Agentic Tool-calling and RL Training},
  author={Liu, Tong and Qian, Cheng and Cief, Matej and He, Yuan and Dan, Daniele and Aletras, Nikolaos and Kazai, Gabriella},
  journal={arXiv preprint arXiv:2606.00135},
  year={2026}
}

```