### PR TITLE
Add ClawBench to web-agent benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1388,6 +1388,7 @@ Here are the extracted citation tables grouped by their respective sections.
 | [BrowseComp: A Simple Yet Challenging Benchmark for Browsing Agents](https://arxiv.org/abs/2504.12516) | 2025 |
 | [BrowseComp-ZH: Benchmarking Web Browsing Ability of Large Language Models in Chinese](https://www.arxiv.org/abs/2504.19314) | 2025 |
 | [Video-Browser: Towards Agentic Open-web Video Browsing](https://arxiv.org/pdf/2512.23044) | 2025 |
+| [ClawBench: Can AI Agents Complete Everyday Online Tasks?](https://arxiv.org/abs/2604.08523) | 2026 |
 
 
 #### General Tool-Use Agents


### PR DESCRIPTION
## Summary

This adds one paper row for ClawBench to the Web Agents benchmark table.

The placement follows the existing two-column Paper/Year layout and uses the canonical arXiv abstract URL. ClawBench belongs in this subsection because it measures agentic reasoning and action across long, real-world browser workflows rather than isolated page interactions.

Checks performed:

- `git diff --check origin/main...HEAD`
- Confirmed the new row has the same two-column structure as its neighbors.
- Confirmed the arXiv URL resolves successfully.

Disclosure: I am a ClawBench maintainer. This is an openly identified maintainer submission, limited to the single entry supported by the list scope.
